### PR TITLE
updating composer json with new releases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,12 @@
             "email": "alex@jump24.co.uk",
             "homepage": "https://jump24.co.uk",
             "role": "Lead Developer"
+        },
+        {
+            "name": "Daniel Newns",
+            "email": "dan@jump24.co.uk",
+            "homepage": "https://jump24.co.uk",
+            "role": "Developer"
         }
     ],
     "autoload": {
@@ -29,10 +35,9 @@
     },
     "require": {
         "php": "^7.2|^8.0",
-        "nunomaduro/larastan": "^0.6.11|^0.7",
+        "nunomaduro/larastan": "^1.0.0",
         "nikic/php-parser": "^4.0",
         "laravel/framework": "^6.0|^7.0|^8.0",
-        "phpstan/phpstan-strict-rules": "^0.12.9",
         "jumptwentyfour/php-coding-standards": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
This adds the new Larastan and PHPStan release and removes strict rules as no longer required.

Signed-off-by: Daniel Newns <dan@jump24.co.uk>