### PR TITLE
Remove phpstan-strict-rules neon include

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,4 @@
 includes:
-    - ../../phpstan/phpstan-strict-rules/rules.neon
     - ../../nunomaduro/larastan/extension.neon
 
 parameters:


### PR DESCRIPTION
Remove phpstan-strict-rules neon include as it's not required by composer anymore.