### PR TITLE
updating laravel coding standards to work with ecs 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,39 +31,19 @@ This will run the configured code standard checks for you, giving you feedback o
 
 ## Extending
 
-These code standards are extendable, all you need to do is create your own `ecs.php` in the root directory of your project:
+These code standards are extendable, all you need to do is create your own `ecs.php` in the root directory of your project and copy the following and extend as required:
 
 ```php
 <?php
 
 declare(strict_types=1);
 
-use JumpTwentyFour\PhpCodingStandards\Support\ConfigHelper;
-use Symplify\EasyCodingStandard\Config\ECSConfig;
-use Symplify\EasyCodingStandard\ValueObject\Option;
-
-return static function (ECSConfig $ecsConfig): void {
-    $ecsConfig->import(__DIR__ . '/vendor/jumptwentyfour/laravel-coding-standards/ecs.php');
-
-    $ecsConfig->paths([
-        __DIR__ . '/app',
-        __DIR__ . '/config',
-        __DIR__ . '/database',
-        __DIR__ . '/routes',
-        __DIR__ . '/tests',
-    ]);
-    
-    $ecsConfig->skip(array_merge(ConfigHelper::make()->getParameter(Option::SKIP), [
-        UnusedParameterSniff::class => [
-            __DIR__ . '/app/Console/Kernel.php',
-            __DIR__ . '/app/Exceptions/Handler.php',
-        ],
-        'Unused parameter $attributes.' => [
-            __DIR__ . '/database/*.php',
-        ],
-        CamelCapsFunctionNameSniff::class => [
-            '/tests/**',
-        ],
-    ]));
-};
+return ECSConfig::configure()
+    ->withSets([getcwd() . '/vendor/jumptwentyfour/php-coding-standards/ecs.php'])
+    ->withPaths(
+        [
+            __DIR__ . '/ecs.php',
+            __DIR__ . '/src',
+        ]
+    );
 ```

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,9 @@
     "require": {
         "php": "^7.2|^8.0",
         "larastan/larastan": "^2.7.0",
-        "nikic/php-parser": "^4.0",
+        "nikic/php-parser": "^5.0",
         "laravel/framework": "^7.0|^8.0|^9.0|^10.0",
-        "jumptwentyfour/php-coding-standards": "^2.2"
+        "jumptwentyfour/php-coding-standards": "^v3.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3"

--- a/ecs.php
+++ b/ecs.php
@@ -1,15 +1,14 @@
 <?php
 
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symplify\EasyCodingStandard\ValueObject\Option;
+declare(strict_types=1);
 
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $parameters = $containerConfigurator->parameters();
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/ecs.php',
-        __DIR__ . '/src',
-    ]);
-
-    $containerConfigurator->import(getcwd() . '/vendor/jumptwentyfour/php-coding-standards/ecs.php');
-};
+return ECSConfig::configure()
+    ->withSets([getcwd() . '/vendor/jumptwentyfour/php-coding-standards/ecs.php'])
+    ->withPaths(
+        [
+            __DIR__ . '/ecs.php',
+            __DIR__ . '/src',
+        ]
+    );

--- a/src/Laravel/PHPStan/RequestValidationRule.php
+++ b/src/Laravel/PHPStan/RequestValidationRule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JumpTwentyFour\LaravelCodingStandards\Laravel\PHPStan;
 
 use Illuminate\Http\Request;


### PR DESCRIPTION
This brings in the latest version of our php coding standards package and also upgrades the base ECS File