### PR TITLE
Update phpstan config file for PHPStan 2 and Laravel 12

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,10 +6,11 @@ parameters:
     paths:
         - ../../../app
     excludePaths:
-        - '.phpstorm.meta.php'
-        - '_ide_helper.php'
-        - 'server.php'
-    checkMissingIterableValueType: false
+        - '../../../.phpstorm.meta.php (?)'
+        - '../../../_ide_helper.php (?)'
+        - '../../../server.php (?)'
+    ignoreErrors:
+        - identifier: missingType.iterableValue
     checkUninitializedProperties: true
 
 rules:


### PR DESCRIPTION
When getting the GCC API working on Laravel 12 I had some issues running PHPStan, the major ones were 

```
Path "/Users/jamiepeters/Code/gcc-docker/gcc-api/vendor/jumptwentyfour/laravel-coding-standards/.phpstorm.meta.php" is neither a directory, nor a file path, nor a fnmatch pattern.

Path "/Users/jamiepeters/Code/gcc-docker/gcc-api/vendor/jumptwentyfour/laravel-coding-standards/_ide_helper.php" is neither a directory, nor a file path, nor a fnmatch pattern.

Path "/Users/jamiepeters/Code/gcc-docker/gcc-api/vendor/jumptwentyfour/laravel-coding-standards/server.php" is neither a directory, nor a file path, nor a fnmatch pattern.

If the excluded path can sometimes exist, append (?)
to its config entry to mark it as optional. Example:

parameters:
	excludePaths:
		analyseAndScan:
			- vendor/jumptwentyfour/laravel-coding-standards/.phpstorm.meta.php (?)
			- vendor/jumptwentyfour/laravel-coding-standards/_ide_helper.php (?)
			- vendor/jumptwentyfour/laravel-coding-standards/server.php (?)
```

This comes from the phpstan.neon file here setting the above files as excluded in the root directory, so running PHPStan in the project would then look in the root directory of the _package_ rather than the app, so being explicit with the directory in the same way of the path option above fixed this.

The other change is from a removed option in the config file - https://github.com/phpstan/phpstan/blob/2.1.x/UPGRADING.md#removed-option-checkmissingiterablevaluetype

---- 

Using this config locally in the vendor folder works in the GCC API repo for me on Laravel 12, but I've not tested it on earlier versions.